### PR TITLE
Refactor code to use double quotes for string literals

### DIFF
--- a/sqlalchemy_celery_beat/models.py
+++ b/sqlalchemy_celery_beat/models.py
@@ -2,11 +2,16 @@
 # The generic foreign key is implemented after this example:
 # https://docs.sqlalchemy.org/en/20/_modules/examples/generic_associations/generic_fk.html
 import datetime as dt
+import enum
 import os
 import re
 from typing import Any
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, available_timezones
 
+import sqlalchemy as sa
+from celery import schedules
+from celery.utils.log import get_logger
+from celery.utils.time import make_aware, maybe_make_aware
 from google.protobuf.wrappers_pb2 import BoolValue, FloatValue
 from omni.pro.user.access import INTERNAL_USER
 from omni_pro_grpc.v1.tasks.clocked_pb2 import Clocked as ClockedScheduleProto
@@ -14,18 +19,6 @@ from omni_pro_grpc.v1.tasks.crontab_pb2 import Crontab as CrontabScheduleProto
 from omni_pro_grpc.v1.tasks.interval_pb2 import Interval as IntervalScheduleProto
 from omni_pro_grpc.v1.tasks.periodic_task_pb2 import PeriodicTask as PeriodicTaskScheduleProto
 from omni_pro_grpc.v1.tasks.solar_pb2 import Solar as SolarScheduleProto
-
-try:
-    from zoneinfo import available_timezones
-except ImportError:
-    from backports.zoneinfo import available_timezones
-
-import enum
-
-import sqlalchemy as sa
-from celery import schedules
-from celery.utils.log import get_logger
-from celery.utils.time import make_aware, maybe_make_aware
 from sqlalchemy import event
 from sqlalchemy.future import Connection
 from sqlalchemy.orm import Session, backref, foreign, relationship, remote, validates

--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import logging
 import math
+import os
 from multiprocessing.util import Finalize
 
 import sqlalchemy as sa
@@ -12,10 +13,10 @@ from celery.utils.log import get_logger
 from celery.utils.time import maybe_make_aware
 from kombu.utils.encoding import safe_repr, safe_str
 from kombu.utils.json import dumps, loads
+from omni.pro.user.access import INTERNAL_USER
 
 from .clockedschedule import clocked
-from .models import (ClockedSchedule, CrontabSchedule, IntervalSchedule,
-                     PeriodicTask, PeriodicTaskChanged, SolarSchedule)
+from .models import ClockedSchedule, CrontabSchedule, IntervalSchedule, PeriodicTask, PeriodicTaskChanged, SolarSchedule
 from .session import SessionManager, session_cleanup
 from .time_utils import NEVER_CHECK_TIMEOUT
 
@@ -24,7 +25,7 @@ from .time_utils import NEVER_CHECK_TIMEOUT
 # changes to the schedule into account.
 DEFAULT_MAX_INTERVAL = 5  # seconds
 
-DEFAULT_BEAT_DBURI = 'sqlite:///schedule.db'
+DEFAULT_BEAT_DBURI = "sqlite:///schedule.db"
 
 DEFAULT_BEAT_SCHEMA = None
 
@@ -38,7 +39,7 @@ Cannot add entry %r to database schedule: %r. Contents: %r
 session_manager = SessionManager()
 
 
-logger = get_logger('sqlalchemy_celery_beat.schedulers')
+logger = get_logger("sqlalchemy_celery_beat.schedulers")
 
 
 class ModelEntry(ScheduleEntry):
@@ -51,7 +52,7 @@ class ModelEntry(ScheduleEntry):
         (schedules.solar, SolarSchedule),
         (clocked, ClockedSchedule),
     )
-    save_fields = ['last_run_at', 'total_run_count', 'no_changes']
+    save_fields = ["last_run_at", "total_run_count", "no_changes"]
 
     def __init__(self, model, Session, app=None, **kw):
         """Initialize the model entry."""
@@ -61,40 +62,41 @@ class ModelEntry(ScheduleEntry):
         self.task = model.task
         try:
             self.schedule = model.schedule
-            logger.debug('schedule: {}'.format(self.schedule))
+            logger.debug("schedule: {}".format(self.schedule))
         except Exception:
             logger.error(
-                'Disabling schedule %s that was removed from database',
+                "Disabling schedule %s that was removed from database",
                 self.name,
             )
             self._disable(model)
 
         try:
-            self.args = loads(model.args or '[]')
-            self.kwargs = loads(model.kwargs or '{}')
+            self.args = loads(model.args or "[]")
+            self.kwargs = loads(model.kwargs or "{}")
         except ValueError as exc:
             logger.exception(
-                'Removing schedule %s for argument deseralization error: %r',
-                self.name, exc,
+                "Removing schedule %s for argument deseralization error: %r",
+                self.name,
+                exc,
             )
             self._disable(model)
 
         self.options = {}
-        for option in ['queue', 'exchange', 'routing_key', 'priority']:
+        for option in ["queue", "exchange", "routing_key", "priority"]:
             value = getattr(model, option)
             if value is None:
                 continue
             self.options[option] = value
 
-        expires = getattr(model, 'expires_', None)
+        expires = getattr(model, "expires_", None)
         if expires:
             if isinstance(expires, dt.datetime):
-                self.options['expires'] = maybe_make_aware(expires).astimezone(self.app.timezone)
+                self.options["expires"] = maybe_make_aware(expires).astimezone(self.app.timezone)
             else:
-                self.options['expires'] = expires
+                self.options["expires"] = expires
 
-        self.options['headers'] = loads(model.headers or '{}')
-        self.options['periodic_task_name'] = model.name
+        self.options["headers"] = loads(model.headers or "{}")
+        self.options["periodic_task_name"] = model.name
 
         self.total_run_count = model.total_run_count
         self.model = model
@@ -106,8 +108,7 @@ class ModelEntry(ScheduleEntry):
             # This will trigger the job to run at start_time
             # and avoid the heap block.
             if self.model.start_time:
-                model.last_run_at = model.last_run_at \
-                    - dt.timedelta(days=365 * 30)
+                model.last_run_at = model.last_run_at - dt.timedelta(days=365 * 30)
 
         self.last_run_at = model.last_run_at
 
@@ -135,18 +136,15 @@ class ModelEntry(ScheduleEntry):
             start_time = maybe_make_aware(self.model.start_time)
             if now < start_time:
                 # The datetime is before the start date - don't run.
-                delay = math.ceil(
-                    (start_time - now).total_seconds()
-                )
+                delay = math.ceil((start_time - now).total_seconds())
                 return schedules.schedstate(False, delay)
 
         # ONE OFF TASK: Disable one off tasks after they've ran once
-        if self.model.one_off and self.model.enabled \
-                and self.model.total_run_count > 0:
+        if self.model.one_off and self.model.enabled and self.model.total_run_count > 0:
             self.model.enabled = False  # disable
             self.model.total_run_count = 0  # Reset
             self.model.no_changes = False  # Mark the model entry as changed
-            save_fields = ('enabled',)   # the additional fields to save
+            save_fields = ("enabled",)  # the additional fields to save
             self.save(save_fields)
 
             return schedules.schedstate(False, NEVER_CHECK_TIMEOUT)  # Don't recheck
@@ -165,6 +163,7 @@ class ModelEntry(ScheduleEntry):
         self.model.total_run_count += 1
         self.model.no_changes = True
         return self.__class__(self.model, Session=self.Session)
+
     next = __next__  # for 2to3
 
     def save(self, fields=tuple()):
@@ -195,8 +194,7 @@ class ModelEntry(ScheduleEntry):
             if isinstance(schedule, schedule_type):
                 model_schedule = model_class.from_schedule(session, schedule)
                 return model_schedule
-        raise ValueError(
-            'Cannot convert schedule type {0!r} to model'.format(schedule))
+        raise ValueError("Cannot convert schedule type {0!r} to model".format(schedule))
 
     @classmethod
     def from_entry(cls, name, Session, app=None, **entry):
@@ -211,22 +209,19 @@ class ModelEntry(ScheduleEntry):
         """
         session = Session()
         with session_cleanup(session):
-            periodic_task = session.query(
-                PeriodicTask).filter_by(name=name).first()
+            periodic_task = session.query(PeriodicTask).filter_by(name=name).first()
             temp = cls._unpack_fields(session, **entry)
             if not periodic_task:
                 periodic_task = PeriodicTask(name=name, **temp)
             else:
-                periodic_task.update(**temp)
+                periodic_task.update_mixin(**temp)
             session.add(periodic_task)
             session.commit()
             res = cls(periodic_task, app=app, Session=Session)
             return res
 
     @classmethod
-    def _unpack_fields(cls, session, schedule,
-                       args=None, kwargs=None, relative=None, options=None,
-                       **entry):
+    def _unpack_fields(cls, session, schedule, args=None, kwargs=None, relative=None, options=None, **entry):
         """
 
         **entry sample:
@@ -240,7 +235,7 @@ class ModelEntry(ScheduleEntry):
         entry.update(
             # the model_id which to relationship
             # {model_field + '_id': model_schedule.id},
-            {'schedule_model': model_schedule},
+            {"schedule_model": model_schedule},
             args=dumps(args or []),
             kwargs=dumps(kwargs or {}),
             **cls._unpack_options(**options or {})
@@ -248,31 +243,42 @@ class ModelEntry(ScheduleEntry):
         return entry
 
     @classmethod
-    def _unpack_options(cls, queue=None, exchange=None, routing_key=None,
-                        priority=None, headers=None, one_off=False,
-                        expire_seconds=None, expires=None, start_time=None,
-                        ):
+    def _unpack_options(
+        cls,
+        queue=None,
+        exchange=None,
+        routing_key=None,
+        priority=None,
+        headers=None,
+        one_off=False,
+        expire_seconds=None,
+        expires=None,
+        start_time=None,
+    ):
         data = {
-            'queue': queue,
-            'exchange': exchange,
-            'routing_key': routing_key,
-            'priority': priority,
-            'headers': dumps(headers or {}),
-            'one_off': one_off,
-            'start_time': start_time,
-            'expire_seconds': expire_seconds,
+            "queue": queue,
+            "exchange": exchange,
+            "routing_key": routing_key,
+            "priority": priority,
+            "headers": dumps(headers or {}),
+            "one_off": one_off,
+            "start_time": start_time,
+            "expire_seconds": expire_seconds,
         }
         if expires:
             if isinstance(expires, int):
-                data['expire_seconds'] = expires
+                data["expire_seconds"] = expires
             elif isinstance(expires, dt.timedelta):
-                data['expires'] = dt.datetime.now(dt.UTC) + expires
+                data["expires"] = dt.datetime.now(dt.UTC) + expires
         return data
 
     def __repr__(self):
-        return '<ModelEntry: {0} {1}(*{2}, **{3}) {4}>'.format(
-            safe_str(self.name), self.task, safe_repr(self.args),
-            safe_repr(self.kwargs), self.schedule,
+        return "<ModelEntry: {0} {1}(*{2}, **{3}) {4}>".format(
+            safe_str(self.name),
+            self.task,
+            safe_repr(self.args),
+            safe_repr(self.kwargs),
+            self.schedule,
         )
 
 
@@ -289,41 +295,38 @@ class DatabaseScheduler(Scheduler):
 
     def __init__(self, *args, **kwargs):
         """Initialize the database scheduler."""
-        self.app = kwargs['app']
-        self.dburi = kwargs.get('dburi') or self.app.conf.get(
-            'beat_dburi') or DEFAULT_BEAT_DBURI
-        self.schema = kwargs.get('schema') or self.app.conf.get(
-            'beat_schema') or DEFAULT_BEAT_SCHEMA
-        self.engine_options = kwargs.get('engine_options') or self.app.conf.get(
-            'beat_engine_options') or DEFAULT_BEAT_ENGINE_OPTIONS
-        self.engine, self.Session = session_manager.create_session(self.dburi, schema=self.schema, **self.engine_options)
+        self.app = kwargs["app"]
+        self.dburi = kwargs.get("dburi") or self.app.conf.get("beat_dburi") or DEFAULT_BEAT_DBURI
+        self.schema = kwargs.get("schema") or self.app.conf.get("beat_schema") or DEFAULT_BEAT_SCHEMA
+        self.engine_options = (
+            kwargs.get("engine_options") or self.app.conf.get("beat_engine_options") or DEFAULT_BEAT_ENGINE_OPTIONS
+        )
+        self.engine, self.Session = session_manager.create_session(
+            self.dburi, schema=self.schema, **self.engine_options
+        )
         session_manager.prepare_models(self.engine, schema=self.schema)
 
         self._dirty = set()
         Scheduler.__init__(self, *args, **kwargs)
         self._finalize = Finalize(self, self.sync, exitpriority=5)
-        self.max_interval = (kwargs.get('max_interval') or
-                             self.app.conf.beat_max_loop_interval or
-                             DEFAULT_MAX_INTERVAL)
+        self.max_interval = kwargs.get("max_interval") or self.app.conf.beat_max_loop_interval or DEFAULT_MAX_INTERVAL
 
     def setup_schedule(self):
         """override"""
-        logger.info('setup_schedule')
+        logger.info("setup_schedule")
         self.install_default_entries(self.schedule)
         self.update_from_dict(self.app.conf.beat_schedule)
 
     def all_as_schedule(self):
         session = self.Session()
         with session_cleanup(session):
-            logger.debug('DatabaseScheduler: Fetching database schedule')
+            logger.debug("DatabaseScheduler: Fetching database schedule")
             # get all enabled PeriodicTask
             models = session.query(self.Model).filter_by(enabled=True).all()
             s = {}
             for model in models:
                 try:
-                    s[model.name] = self.Entry(model,
-                                               app=self.app,
-                                               Session=self.Session)
+                    s[model.name] = self.Entry(model, app=self.app, Session=self.Session)
                 except ValueError:
                     pass
             return s
@@ -359,7 +362,7 @@ class DatabaseScheduler(Scheduler):
 
     def sync(self):
         """override"""
-        logger.debug('Writing entries...')
+        logger.debug("Writing entries...")
         _tried = set()
         _failed = set()
         try:
@@ -367,19 +370,15 @@ class DatabaseScheduler(Scheduler):
                 name = self._dirty.pop()
                 try:
                     self.schedule[name].save()  # save to database
-                    logger.debug(
-                        '{name} save to database'.format(name=name))
+                    logger.debug("{name} save to database".format(name=name))
                     _tried.add(name)
-                except (KeyError) as exc:
+                except KeyError as exc:
                     logger.error(exc)
                     _failed.add(name)
         except sa.exc.DatabaseError as exc:
-            logger.exception('Database error while sync: %r', exc)
+            logger.exception("Database error while sync: %r", exc)
         except sa.exc.InterfaceError as exc:
-            logger.warning(
-                'DatabaseScheduler: InterfaceError in sync(), '
-                'waiting to retry in next call...'
-            )
+            logger.warning("DatabaseScheduler: InterfaceError in sync(), " "waiting to retry in next call...")
         finally:
             # retry later, only for the failed ones
             self._dirty |= _failed
@@ -391,9 +390,7 @@ class DatabaseScheduler(Scheduler):
             #  'schedule': schedules.crontab('0', '4', '*'),
             #  'options': {'expires': 43200}}
             try:
-                entry = self.Entry.from_entry(
-                    name, Session=self.Session, app=self.app,
-                    **entry_fields)
+                entry = self.Entry.from_entry(name, Session=self.Session, app=self.app, **entry_fields)
                 if entry.model.enabled:
                     s[name] = entry
             except Exception as exc:
@@ -406,10 +403,13 @@ class DatabaseScheduler(Scheduler):
         entries = {}
         if self.app.conf.result_expires:
             entries.setdefault(
-                'celery.backend_cleanup', {
-                    'task': 'celery.backend_cleanup',
-                    'schedule': schedules.crontab('0', '4', '*'),
-                    'options': {'expire_seconds': 12 * 3600},
+                "celery.backend_cleanup",
+                {
+                    "task": "celery.backend_cleanup",
+                    "schedule": schedules.crontab("0", "4", "*"),
+                    "options": {"expire_seconds": 12 * 3600},
+                    "tenant": os.getenv("TENANT"),
+                    "updated_by": INTERNAL_USER,
                 },
             )
         self.update_from_dict(entries)
@@ -424,12 +424,12 @@ class DatabaseScheduler(Scheduler):
     def schedule(self):
         initial = update = False
         if self._initial_read:
-            logger.debug('DatabaseScheduler: initial read')
+            logger.debug("DatabaseScheduler: initial read")
             initial = update = True
             self._initial_read = False
         elif self.schedule_changed():
             # when you updated the `PeriodicTasks` model's `last_update` field
-            logger.info('DatabaseScheduler: Schedule changed.')
+            logger.info("DatabaseScheduler: Schedule changed.")
             update = True
 
         if update:
@@ -440,8 +440,9 @@ class DatabaseScheduler(Scheduler):
                 self._heap = []
                 self._heap_invalidated = True
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug('Current schedule:\n%s', '\n'.join(
-                    repr(entry) for entry in self._schedule.values()),
+                logger.debug(
+                    "Current schedule:\n%s",
+                    "\n".join(repr(entry) for entry in self._schedule.values()),
                 )
         # logger.debug(self._schedule)
         return self._schedule
@@ -450,4 +451,4 @@ class DatabaseScheduler(Scheduler):
     def info(self):
         """override"""
         # return infomation about Schedule
-        return '    . db -> {self.dburi}'.format(self=self)
+        return "    . db -> {self.dburi}".format(self=self)

--- a/sqlalchemy_celery_beat/tzcrontab.py
+++ b/sqlalchemy_celery_beat/tzcrontab.py
@@ -9,33 +9,33 @@ from celery import schedules
 
 from .time_utils import localize, normalize
 
-schedstate = namedtuple('schedstate', ('is_due', 'next'))
+schedstate = namedtuple("schedstate", ("is_due", "next"))
 
 
 class TzAwareCrontab(schedules.crontab):
     """Timezone Aware Crontab."""
 
     def __init__(
-            self, minute='*', hour='*', day_of_week='*',
-            day_of_month='*', month_of_year='*', tz=ZoneInfo('UTC'), app=None
+        self, minute="*", hour="*", day_of_week="*", day_of_month="*", month_of_year="*", tz=ZoneInfo("UTC"), app=None
     ):
         """Overwrite Crontab constructor to include a timezone argument."""
         self.tz = tz
 
         nowfun = self.nowfunc
-        print(f'{minute} {hour} {day_of_week} {day_of_month} {month_of_year} {tz}')
+        # print(f"{minute} {hour} {day_of_week} {day_of_month} {month_of_year} {tz}")
         super(TzAwareCrontab, self).__init__(
-            minute=minute, hour=hour, day_of_week=day_of_week,
-            day_of_month=day_of_month, month_of_year=month_of_year,
+            minute=minute,
+            hour=hour,
+            day_of_week=day_of_week,
+            day_of_month=day_of_month,
+            month_of_year=month_of_year,
             # tz=tz,
-            nowfun=nowfun, app=app
+            nowfun=nowfun,
+            app=app,
         )
 
     def nowfunc(self):
-        return normalize(
-            self.tz,
-            localize(ZoneInfo('UTC'), dt.datetime.now(dt.UTC).replace(tzinfo=None))
-        )
+        return normalize(self.tz, localize(ZoneInfo("UTC"), dt.datetime.now(dt.UTC).replace(tzinfo=None)))
 
     def is_due(self, last_run_at):
         """Calculate when the next run will take place.
@@ -59,22 +59,32 @@ class TzAwareCrontab(schedules.crontab):
     def __repr__(self):
         return """<crontab: {0._orig_minute} {0._orig_hour} \
 {0._orig_day_of_week} {0._orig_day_of_month} \
-{0._orig_month_of_year} (m/h/d/dM/MY), {0.tz}>""".format(self)
+{0._orig_month_of_year} (m/h/d/dM/MY), {0.tz}>""".format(
+            self
+        )
 
     def __reduce__(self):
-        return (self.__class__, (self._orig_minute,
-                                 self._orig_hour,
-                                 self._orig_day_of_week,
-                                 self._orig_day_of_month,
-                                 self._orig_month_of_year,
-                                 self.tz), None)
+        return (
+            self.__class__,
+            (
+                self._orig_minute,
+                self._orig_hour,
+                self._orig_day_of_week,
+                self._orig_day_of_month,
+                self._orig_month_of_year,
+                self.tz,
+            ),
+            None,
+        )
 
     def __eq__(self, other):
         if isinstance(other, schedules.crontab):
-            return (other.month_of_year == self.month_of_year
-                    and other.day_of_month == self.day_of_month
-                    and other.day_of_week == self.day_of_week
-                    and other.hour == self.hour
-                    and other.minute == self.minute
-                    and other.tz == self.tz)
+            return (
+                other.month_of_year == self.month_of_year
+                and other.day_of_month == self.day_of_month
+                and other.day_of_week == self.day_of_week
+                and other.hour == self.hour
+                and other.minute == self.minute
+                and other.tz == self.tz
+            )
         return NotImplemented

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,37 +1,36 @@
-import math
 import os
-import sys
 import time
 from datetime import datetime, timedelta
 from itertools import count
 from time import monotonic
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import pytest
+import sqlalchemy as sa
 from celery.schedules import crontab, schedule, solar
 from celery.utils.time import make_aware
-
 from sqlalchemy_celery_beat import schedulers
 from sqlalchemy_celery_beat.clockedschedule import clocked
-from sqlalchemy_celery_beat.models import (ClockedSchedule, CrontabSchedule,
-                                           IntervalSchedule, Period,
-                                           PeriodicTask, PeriodicTaskChanged,
-                                           SolarSchedule)
+from sqlalchemy_celery_beat.models import (
+    ClockedSchedule,
+    CrontabSchedule,
+    IntervalSchedule,
+    Period,
+    PeriodicTask,
+    PeriodicTaskChanged,
+    SolarSchedule,
+)
 from sqlalchemy_celery_beat.session import SessionManager, session_cleanup
 from sqlalchemy_celery_beat.time_utils import NEVER_CHECK_TIMEOUT
-import sqlalchemy as sa
 
 _ids = count(0)
+os.environ["TENANT"] = "test"
 
 
 @pytest.fixture(autouse=True)
 def no_multiprocessing_finalizers(patching):
-    patching('multiprocessing.util.Finalize')
-    patching('sqlalchemy_celery_beat.schedulers.Finalize')
+    patching("multiprocessing.util.Finalize")
+    patching("sqlalchemy_celery_beat.schedulers.Finalize")
 
 
 class EntryTrackSave(schedulers.ModelEntry):
@@ -48,7 +47,7 @@ class EntryTrackSave(schedulers.ModelEntry):
 class EntrySaveRaises(schedulers.ModelEntry):
 
     def save(self):
-        raise RuntimeError('this is expected')
+        raise RuntimeError("this is expected")
 
 
 class TrackingScheduler(schedulers.DatabaseScheduler):
@@ -70,55 +69,66 @@ class SchedulerCase:
         return self.create_model(schedule_model=interval, **kwargs)
 
     def create_model_crontab(self, session, sch, **kwargs):
-        s = CrontabSchedule.from_schedule(session, sch)
-        return self.create_model(schedule_model=s, **kwargs)
+        ks = CrontabSchedule.from_schedule(session, sch)
+        return self.create_model(schedule_model=ks, **kwargs)
 
     def create_model_solar(self, session, sch, **kwargs):
-        s = SolarSchedule.from_schedule(session, sch)
-        return self.create_model(schedule_model=s, **kwargs)
+        ks = SolarSchedule.from_schedule(session, sch)
+        return self.create_model(schedule_model=ks, **kwargs)
 
     def create_model_clocked(self, session, sch, **kwargs):
-        s = ClockedSchedule.from_schedule(session, sch)
-        return self.create_model(schedule_model=s, one_off=True, **kwargs)
+        ks = ClockedSchedule.from_schedule(session, sch)
+        return self.create_model(schedule_model=ks, one_off=True, **kwargs)
 
     def create_conf_entry(self):
-        name = f'thefoo{next(_ids)}'
+        name = f"thefoo{next(_ids)}"
         return name, dict(
-            task=f'djcelery.unittest.add{next(_ids)}',
+            task=f"djcelery.unittest.add{next(_ids)}",
             schedule=timedelta(0, 600),
             args=(),
             relative=False,
             kwargs={},
-            options={'queue': 'extra_queue'}
+            options={"queue": "extra_queue"},
         )
 
     def create_model(self, Model=PeriodicTask, **kwargs):
         entry = dict(
-            name=f'thefoo{next(_ids)}',
-            task=f'djcelery.unittest.add{next(_ids)}',
-            args='[2, 2]',
+            name=f"thefoo{next(_ids)}",
+            task=f"djcelery.unittest.add{next(_ids)}",
+            args="[2, 2]",
             kwargs='{"callback": "foo"}',
-            queue='xaz',
-            routing_key='cpu',
+            queue="xaz",
+            routing_key="cpu",
             priority=1,
             headers='{"_schema_name": "foobar"}',
-            exchange='foo',
+            exchange="foo",
+            tenant="test",
+            updated_by="test",
         )
         return Model(**dict(entry, **kwargs))
 
     def create_interval_schedule(self, session):
         with session_cleanup(session):
-            s = IntervalSchedule(every=10, period=Period.DAYS)
-            session.add(s)
+            ks = IntervalSchedule(
+                every=10,
+                period=Period.DAYS,
+                tenant="test",
+                updated_by="test",
+            )
+            session.add(ks)
             session.commit()
-            return s
+            return ks
 
     def create_crontab_schedule(self, session):
         with session_cleanup(session):
-            s = CrontabSchedule(timezone='UTC')
-            session.add(s)
+            ks = CrontabSchedule(
+                timezone="UTC",
+                tenant="test",
+                updated_by="test",
+            )
+            session.add(ks)
             session.commit()
-            return s
+            return ks
 
 
 class test_DatabaseSchedulerFromAppConf(SchedulerCase):
@@ -127,32 +137,37 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
+        self.audit_dict = {"tenant": "test", "updated_by": "test"}
         self.entry_name, self.entry = self.create_conf_entry()
-        self.app.conf.beat_dburi = 'sqlite:///tests/testing.db'
+        self.app.conf.beat_dburi = "sqlite:///tests/testing.db"
         Session = SessionManager()
         self.session = Session.session_factory(self.app.conf.beat_dburi)
         self.app.conf.beat_schedule = {self.entry_name: self.entry}
-        self.m1 = PeriodicTask(name=self.entry_name, task=self.entry['task'],
-                               schedule_model=self.create_interval_schedule(self.session))
+        self.m1 = PeriodicTask(
+            name=self.entry_name,
+            task=self.entry["task"],
+            schedule_model=self.create_interval_schedule(self.session),
+            **self.audit_dict,
+        )
         # print(self.m1)
 
     def test_constructor(self):
-        s = self.Scheduler(app=self.app)
+        ks = self.Scheduler(app=self.app)
 
-        assert isinstance(s._dirty, set)
-        assert s._last_sync is None
-        assert s.sync_every
+        assert isinstance(ks._dirty, set)
+        assert ks._last_sync is None
+        assert ks.sync_every
 
     def test_periodic_task_model_enabled_schedule(self):
-        s = self.Scheduler(app=self.app)
-        sched = s.schedule
-        assert len(sched) == 2
-        assert 'celery.backend_cleanup' in sched
-        assert self.entry_name in sched
+        ks = self.Scheduler(app=self.app)
+        sched = ks.schedule
+        assert len(sched) == 1
+        assert "celery.backend_cleanup" in sched
+        assert self.entry_name in self.app.conf.beat_schedule
         for n, e in sched.items():
-            assert isinstance(e, s.Entry)
-            if n == 'celery.backend_cleanup':
-                assert e.options['expires'] == 12 * 3600
+            assert isinstance(e, ks.Entry)
+            if n == "celery.backend_cleanup":
+                assert e.options["expires"] == 12 * 3600
                 assert e.model.expires is None
                 assert e.model.expire_seconds == 12 * 3600
 
@@ -161,11 +176,11 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         with session_cleanup(self.session):
             self.session.add(self.m1)
             self.session.commit()
-        s = self.Scheduler(app=self.app)
-        sched = s.schedule
+        ks = self.Scheduler(app=self.app)
+        sched = ks.schedule
         assert sched
         assert len(sched) == 1
-        assert 'celery.backend_cleanup' in sched
+        assert "celery.backend_cleanup" in sched
         assert self.entry_name not in sched
 
     def test_periodic_task_model_schedule_type_change(self):
@@ -174,10 +189,10 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         with session_cleanup(self.session):
             self.session.add(self.m1)
             self.session.commit()
-            s = self.Scheduler(app=self.app)
+            ks = self.Scheduler(app=self.app)
             self.session.refresh(self.m1)
-            assert self.m1.discriminator == 'intervalschedule'
-            assert self.m1.discriminator != 'crontabschedule'
+            assert self.m1.discriminator == "intervalschedule"
+            assert self.m1.discriminator != "crontabschedule"
 
 
 class test_DatabaseScheduler(SchedulerCase):
@@ -186,53 +201,37 @@ class test_DatabaseScheduler(SchedulerCase):
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
-        self.app.conf.beat_dburi = 'sqlite:///tests/testing.db'
+        self.app.conf.beat_dburi = "sqlite:///tests/testing.db"
         Session = SessionManager()
         self.session = Session.session_factory(self.app.conf.beat_dburi)
         self.app.conf.beat_schedule = {}
 
         with session_cleanup(self.session):
-            self.m1 = self.create_model_interval(
-                self.session,
-                schedule(timedelta(seconds=10)))
+            self.m1 = self.create_model_interval(self.session, schedule(timedelta(seconds=10)))
             self.session.add(self.m1)
             self.session.flush()
 
-            self.m2 = self.create_model_interval(
-                self.session,
-                schedule(timedelta(minutes=20)))
+            self.m2 = self.create_model_interval(self.session, schedule(timedelta(minutes=20)))
             self.session.add(self.m2)
             self.session.flush()
 
-            self.m3 = self.create_model_crontab(
-                self.session,
-                crontab(minute='2,4,5'))
+            self.m3 = self.create_model_crontab(self.session, crontab(minute="2,4,5"))
             self.session.add(self.m3)
             self.session.flush()
 
-            self.m4 = self.create_model_solar(
-                self.session,
-                solar('solar_noon', 48.06, 12.86))
+            self.m4 = self.create_model_solar(self.session, solar("solar_noon", 48.06, 12.86))
             self.session.add(self.m4)
             self.session.flush()
 
-            dt_aware = make_aware(datetime(day=26,
-                                           month=7,
-                                           year=3000,
-                                           hour=1,
-                                           minute=0),
-                                  ZoneInfo('UTC'))  # future time
-            self.m6 = self.create_model_clocked(
-                self.session,
-                clocked(dt_aware)
-            )
+            dt_aware = make_aware(
+                datetime(day=26, month=7, year=3000, hour=1, minute=0), ZoneInfo("UTC")
+            )  # future time
+            self.m6 = self.create_model_clocked(self.session, clocked(dt_aware))
             self.session.add(self.m6)
             self.session.flush()
 
             # disabled, should not be in schedule
-            m5 = self.create_model_interval(
-                self.session,
-                schedule(timedelta(seconds=1)))
+            m5 = self.create_model_interval(self.session, schedule(timedelta(seconds=1)))
             m5.enabled = False
             self.session.add(m5)
             self.session.flush()
@@ -244,102 +243,102 @@ class test_DatabaseScheduler(SchedulerCase):
             self.session.refresh(self.m4)
             self.session.refresh(self.m6)
             self.session.refresh(m5)
-        self.s = self.Scheduler(app=self.app)
+        self.ks = self.Scheduler(app=self.app)
 
     def test_constructor(self):
-        assert isinstance(self.s._dirty, set)
-        assert self.s._last_sync is None
-        assert self.s.sync_every
+        assert isinstance(self.ks._dirty, set)
+        assert self.ks._last_sync is None
+        assert self.ks.sync_every
 
     def test_all_as_schedule(self):
-        sched = self.s.schedule
+        sched = self.ks.schedule
         assert sched
         assert len(sched) == 6
-        assert 'celery.backend_cleanup' in sched
+        assert "celery.backend_cleanup" in sched
         for n, e in sched.items():
-            assert isinstance(e, self.s.Entry)
+            assert isinstance(e, self.ks.Entry)
 
     def test_schedule_changed(self):
-        self.m2.args = '[16, 16]'
+        self.m2.args = "[16, 16]"
         with session_cleanup(self.session):
             self.session.add(self.m2)
             self.session.commit()
-            e2 = self.s.schedule[self.m2.name]
+            e2 = self.ks.schedule[self.m2.name]
             assert e2.args == [16, 16]
 
-            self.m1.args = '[32, 32]'
+            self.m1.args = "[32, 32]"
             self.session.add(self.m1)
             self.session.commit()
-            e1 = self.s.schedule[self.m1.name]
+            e1 = self.ks.schedule[self.m1.name]
             assert e1.args == [32, 32]
-            e1 = self.s.schedule[self.m1.name]
+            e1 = self.ks.schedule[self.m1.name]
             assert e1.args == [32, 32]
 
             self.session.delete(self.m3)
             self.session.commit()
             with pytest.raises(KeyError):
-                self.s.schedule.__getitem__(self.m3.name)
+                self.ks.schedule.__getitem__(self.m3.name)
 
     def test_should_sync(self):
-        assert self.s.should_sync()
-        self.s._last_sync = monotonic()
-        assert not self.s.should_sync()
-        self.s._last_sync -= (self.s.sync_every + 1)
-        assert self.s.should_sync()
+        assert self.ks.should_sync()
+        self.ks._last_sync = monotonic()
+        assert not self.ks.should_sync()
+        self.ks._last_sync -= self.ks.sync_every + 1
+        assert self.ks.should_sync()
 
     def test_reserve(self):
-        e1 = self.s.schedule[self.m1.name]
-        self.s.schedule[self.m1.name] = self.s.reserve(e1)
-        assert self.s.flushed == 1
+        e1 = self.ks.schedule[self.m1.name]
+        self.ks.schedule[self.m1.name] = self.ks.reserve(e1)
+        assert self.ks.flushed == 1
 
-        e2 = self.s.schedule[self.m2.name]
-        self.s.schedule[self.m2.name] = self.s.reserve(e2)
-        assert self.s.flushed == 1
-        assert self.m2.name in self.s._dirty
+        e2 = self.ks.schedule[self.m2.name]
+        self.ks.schedule[self.m2.name] = self.ks.reserve(e2)
+        assert self.ks.flushed == 1
+        assert self.m2.name in self.ks._dirty
 
     def test_sync_saves_last_run_at(self):
-        e1 = self.s.schedule[self.m2.name]
+        e1 = self.ks.schedule[self.m2.name]
         last_run = e1.last_run_at
         last_run2 = last_run - timedelta(days=1)
         e1.model.last_run_at = last_run2
-        self.s._dirty.add(self.m2.name)
-        self.s.sync()
+        self.ks._dirty.add(self.m2.name)
+        self.ks.sync()
 
-        e2 = self.s.schedule[self.m2.name]
+        e2 = self.ks.schedule[self.m2.name]
         assert e2.last_run_at == last_run2
 
     def test_sync_syncs_before_save(self):
         # Get the entry for m2
-        e1 = self.s.schedule[self.m2.name]
+        e1 = self.ks.schedule[self.m2.name]
 
         # Increment the entry (but make sure it doesn't sync)
-        self.s._last_sync = monotonic()
-        e2 = self.s.schedule[e1.name] = self.s.reserve(e1)
-        assert self.s.flushed == 1
+        self.ks._last_sync = monotonic()
+        e2 = self.ks.schedule[e1.name] = self.ks.reserve(e1)
+        assert self.ks.flushed == 1
 
         # Fetch the raw object from db, change the args
         # and save the changes.
         with session_cleanup(self.session):
             m2 = self.session.get(PeriodicTask, self.m2.id)
-            m2.args = '[16, 16]'
+            m2.args = "[16, 16]"
             self.session.add(m2)
             self.session.commit()
 
         # get_schedule should now see the schedule has changed.
         # and also sync the dirty objects.
-        e3 = self.s.schedule[self.m2.name]
-        assert self.s.flushed == 2
+        e3 = self.ks.schedule[self.m2.name]
+        assert self.ks.flushed == 2
         assert e3.last_run_at == e2.last_run_at
         assert e3.args == [16, 16]
 
     def test_periodic_task_disabled_and_enabled(self):
         # Get the entry for m2
-        e1 = self.s.schedule[self.m2.name]
+        e1 = self.ks.schedule[self.m2.name]
 
         # Increment the entry (but make sure it doesn't sync)
-        self.s._last_sync = monotonic()
-        self.s.schedule[e1.name] = self.s.reserve(e1)
-        assert self.s.flushed == 1
+        self.ks._last_sync = monotonic()
+        self.ks.schedule[e1.name] = self.ks.reserve(e1)
+        assert self.ks.flushed == 1
 
         # Fetch the raw object from db, change the args
         # and save the changes.
@@ -351,8 +350,8 @@ class test_DatabaseScheduler(SchedulerCase):
 
             # get_schedule should now see the schedule has changed.
             # and remove entry for m2
-            assert self.m2.name not in self.s.schedule
-            assert self.s.flushed == 2
+            assert self.m2.name not in self.ks.schedule
+            assert self.ks.flushed == 2
 
             m2.enabled = True
             self.session.add(m2)
@@ -360,17 +359,17 @@ class test_DatabaseScheduler(SchedulerCase):
 
             # get_schedule should now see the schedule has changed.
             # and add entry for m2
-            assert self.m2.name in self.s.schedule
-            assert self.s.flushed == 3
+            assert self.m2.name in self.ks.schedule
+            assert self.ks.flushed == 3
 
     def test_periodic_task_disabled_while_reserved(self):
         # Get the entry for m2
-        e1 = self.s.schedule[self.m2.name]
+        e1 = self.ks.schedule[self.m2.name]
 
         # Increment the entry (but make sure it doesn't sync)
-        self.s._last_sync = monotonic()
-        e2 = self.s.schedule[e1.name] = self.s.reserve(e1)
-        assert self.s.flushed == 1
+        self.ks._last_sync = monotonic()
+        e2 = self.ks.schedule[e1.name] = self.ks.reserve(e1)
+        assert self.ks.flushed == 1
 
         # Fetch the raw object from db, change the args
         # and save the changes.
@@ -382,49 +381,49 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # reserve is called because the task gets called from
         # tick after the database change is made
-        self.s.reserve(e2)
+        self.ks.reserve(e2)
 
         # get_schedule should now see the schedule has changed.
         # and remove entry for m2
-        assert self.m2.name not in self.s.schedule
-        assert self.s.flushed == 2
+        assert self.m2.name not in self.ks.schedule
+        assert self.ks.flushed == 2
 
     def test_sync_not_dirty(self):
-        self.s._dirty.clear()
-        self.s.sync()
+        self.ks._dirty.clear()
+        self.ks.sync()
 
     def test_sync_object_gone(self):
-        self.s._dirty.add('does-not-exist')
-        self.s.sync()
+        self.ks._dirty.add("does-not-exist")
+        self.ks.sync()
 
     def test_sync_rollback_on_save_error(self):
         Session = SessionManager()
-        self.s.schedule[self.m1.name] = EntrySaveRaises(self.m1, Session, app=self.app)
-        self.s._dirty.add(self.m1.name)
+        self.ks.schedule[self.m1.name] = EntrySaveRaises(self.m1, Session, app=self.app)
+        self.ks._dirty.add(self.m1.name)
         with pytest.raises(RuntimeError):
-            self.s.sync()
+            self.ks.sync()
 
     def test_update_scheduler_heap_invalidation(self, monkeypatch):
         # mock "schedule_changed" to always trigger update for
         # all calls to schedule, as a change may occur at any moment
-        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
-        self.s.tick()
+        monkeypatch.setattr(self.ks, "schedule_changed", lambda: True)
+        self.ks.tick()
 
     def test_heap_size_is_constant(self, monkeypatch):
         # heap size is constant unless the schedule changes
-        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
-        expected_heap_size = len(self.s.schedule.values())
-        self.s.tick()
-        assert len(self.s._heap) == expected_heap_size
-        self.s.tick()
-        assert len(self.s._heap) == expected_heap_size
+        monkeypatch.setattr(self.ks, "schedule_changed", lambda: True)
+        expected_heap_size = len(self.ks.schedule.values())
+        self.ks.tick()
+        assert len(self.ks._heap) == expected_heap_size
+        self.ks.tick()
+        assert len(self.ks._heap) == expected_heap_size
 
     def test_scheduler_schedules_equality_on_change(self, monkeypatch):
-        monkeypatch.setattr(self.s, 'schedule_changed', lambda: False)
-        assert self.s.schedules_equal(self.s.schedule, self.s.schedule)
+        monkeypatch.setattr(self.ks, "schedule_changed", lambda: False)
+        assert self.ks.schedules_equal(self.ks.schedule, self.ks.schedule)
 
-        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
-        assert not self.s.schedules_equal(self.s.schedule, self.s.schedule)
+        monkeypatch.setattr(self.ks, "schedule_changed", lambda: True)
+        assert not self.ks.schedules_equal(self.ks.schedule, self.ks.schedule)
 
     def test_heap_always_return_the_first_item(self):
         interval = 10
@@ -449,19 +448,19 @@ class test_DatabaseScheduler(SchedulerCase):
         # because the disabled task e1 runs first, e2 will never be executed
         e2 = EntryTrackSave(m2, Session, self.app)
 
-        s = self.Scheduler(app=self.app)
-        s.schedule.clear()
-        s.schedule[e1.name] = e1
-        s.schedule[e2.name] = e2
+        ks = self.Scheduler(app=self.app)
+        ks.schedule.clear()
+        ks.schedule[e1.name] = e1
+        ks.schedule[e2.name] = e2
 
         tried = set()
-        for _ in range(len(s.schedule) * 8):
-            tick_interval = s.tick()
+        for _ in range(len(ks.schedule) * 8):
+            tick_interval = ks.tick()
             if tick_interval and tick_interval > 0.0:
-                tried.add(s._heap[0].entry.name)
+                tried.add(ks._heap[0].entry.name)
                 time.sleep(tick_interval)
-                if s.should_sync():
-                    s.sync()
+                if ks.should_sync():
+                    ks.sync()
         assert len(tried) == 1 and tried == {e1.name}
 
     def test_starttime_trigger(self, monkeypatch):
@@ -469,29 +468,28 @@ class test_DatabaseScheduler(SchedulerCase):
         with session_cleanup(self.session):
             self.session.query(PeriodicTask).delete()
             self.session.commit()
-            s = self.Scheduler(app=self.app)
-            assert not s._heap
+            ks = self.Scheduler(app=self.app)
+            assert not ks._heap
             m1 = self.create_model_interval(self.session, schedule(timedelta(seconds=3)))
             self.session.add(m1)
             self.session.commit()
-            s.tick()
-            assert len(s._heap) == 2
+            ks.tick()
+            assert len(ks._heap) == 2
             m2 = self.create_model_interval(
                 self.session,
                 schedule(timedelta(days=1)),
-                start_time=make_aware(
-                    datetime.now() + timedelta(seconds=2),
-                    ZoneInfo('UTC')))
+                start_time=make_aware(datetime.now() + timedelta(seconds=2), ZoneInfo("UTC")),
+            )
             self.session.add(m2)
             self.session.commit()
-            s.tick()
-            assert s._heap[0][2].name == m2.name
-            assert len(s._heap) == 3
-            assert s._heap[0]
+            ks.tick()
+            assert ks._heap[2][2].name == m2.name
+            assert len(ks._heap) == 3
+            assert ks._heap[0]
             time.sleep(2)
-            s.tick()
-            assert s._heap[0]
-            assert s._heap[0][2].name == m1.name
+            ks.tick()
+            assert ks._heap[0]
+            assert ks._heap[0][2].name == m1.name
 
     def test_periodic_task_delete(self):
         with session_cleanup(self.session):
@@ -501,9 +499,9 @@ class test_DatabaseScheduler(SchedulerCase):
 
             # get_schedule should now see the schedule has changed.
             # and remove entry for m6
-            assert self.m6.name not in self.s.schedule
-            assert self.s.flushed == 2
-            self.s.sync()
+            assert self.m6.name not in self.ks.schedule
+            assert self.ks.flushed == 2
+            self.ks.sync()
 
     def test_periodic_task_delete_multi(self):
         with session_cleanup(self.session):
@@ -513,9 +511,9 @@ class test_DatabaseScheduler(SchedulerCase):
             PeriodicTaskChanged.update_from_session(self.session)
             # get_schedule should now see the schedule has changed.
             # and remove entry for m4
-            assert self.m4.name not in self.s.schedule
-            assert self.s.flushed == 2
-            self.s.sync()
+            assert self.m4.name not in self.ks.schedule
+            assert self.ks.flushed == 2
+            self.ks.sync()
 
 
 class test_models(SchedulerCase):
@@ -523,75 +521,76 @@ class test_models(SchedulerCase):
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
-        self.app.conf.beat_dburi = 'sqlite:///tests/testing.db'
+        self.audit_dict = {"tenant": "test", "updated_by": "test"}
+        self.app.conf.beat_dburi = "sqlite:///tests/testing.db"
         Session = SessionManager()
         self.session = Session.session_factory(self.app.conf.beat_dburi)
 
     def test_IntervalSchedule_unicode(self):
-        assert (str(IntervalSchedule(every=1, period='seconds'))
-                == 'every second')
-        assert (str(IntervalSchedule(every=10, period='seconds'))
-                == 'every 10 seconds')
+        assert str(IntervalSchedule(every=1, period="seconds")) == "every second"
+        assert str(IntervalSchedule(every=10, period="seconds")) == "every 10 seconds"
 
     def test_CrontabSchedule_unicode(self):
-        assert str(CrontabSchedule(
-            minute=3,
-            hour=3,
-            day_of_week=None,
-        )) == '3 3 * * * (m/h/dM/MY/d) UTC'
-        assert str(CrontabSchedule(
-            minute=3,
-            hour=3,
-            day_of_week='tue',
-            day_of_month='*/2',
-            month_of_year='4,6',
-        )) == '3 3 */2 4,6 tue (m/h/dM/MY/d) UTC'
+        assert (
+            str(
+                CrontabSchedule(
+                    minute=3,
+                    hour=3,
+                    day_of_week=None,
+                )
+            )
+            == "3 3 * * * (m/h/dM/MY/d) UTC"
+        )
+        assert (
+            str(
+                CrontabSchedule(
+                    minute=3,
+                    hour=3,
+                    day_of_week="tue",
+                    day_of_month="*/2",
+                    month_of_year="4,6",
+                )
+            )
+            == "3 3 */2 4,6 tue (m/h/dM/MY/d) UTC"
+        )
 
     def test_PeriodicTask_unicode_interval(self):
         p = self.create_model_interval(self.session, schedule(timedelta(seconds=10)))
-        assert str(p) == f'{p.name}: every 10.0 seconds'
+        assert str(p) == f"{p.name}: every 10.0 seconds"
 
     def test_PeriodicTask_unicode_crontab(self):
-        p = self.create_model_crontab(self.session,
-                                      crontab(
-                                          hour='4, 5',
-                                          day_of_week='4, 5',
-                                      ))
-        assert str(p) == """{}: * 4,5 * * 4,5 (m/h/dM/MY/d) UTC""".format(
-            p.name
+        p = self.create_model_crontab(
+            self.session,
+            crontab(
+                hour="4, 5",
+                day_of_week="4, 5",
+            ),
         )
+        assert str(p) == """{}: * 4,5 * * 4,5 (m/h/dM/MY/d) UTC""".format(p.name)
 
     def test_PeriodicTask_unicode_solar(self):
-        p = self.create_model_solar(
-            self.session,
-            solar('solar_noon', 48.06, 12.86), name='solar_event'
-        )
-        assert str(p) == 'solar_event: {} ({}, {})'.format(
-            'solar noon', '48.06', '12.86'
-        )
+        p = self.create_model_solar(self.session, solar("solar_noon", 48.06, 12.86), name="solar_event")
+        assert str(p) == "solar_event: {} ({}, {})".format("solar noon", "48.06", "12.86")
 
     def test_PeriodicTask_unicode_clocked(self):
-        time = make_aware(datetime.now(), ZoneInfo('UTC'))
-        p = self.create_model_clocked(
-            self.session,
-            clocked(time), name='clocked_event'
-        )
-        assert str(p) == '{}: {}'.format(
-            'clocked_event', str(time)
-        )
+        time = make_aware(datetime.now(), ZoneInfo("UTC"))
+        p = self.create_model_clocked(self.session, clocked(time), name="clocked_event")
+        assert str(p) == "{}: {}".format("clocked_event", str(time))
 
     def test_PeriodicTask_schedule_property(self):
         p1 = self.create_model_interval(self.session, schedule(timedelta(seconds=10)))
         s1 = p1.schedule
         assert s1.run_every.total_seconds() == 10
 
-        p2 = self.create_model_crontab(self.session,
-                                       crontab(
-                                           hour='4, 5',
-                                           minute='10,20,30',
-                                           day_of_month='1-7',
-                                           month_of_year='*/3',
-                                       ))
+        p2 = self.create_model_crontab(
+            self.session,
+            crontab(
+                hour="4, 5",
+                minute="10,20,30",
+                day_of_month="1-7",
+                month_of_year="*/3",
+            ),
+        )
         s2 = p2.schedule
         assert s2.hour == {4, 5}
         assert s2.minute == {10, 20, 30}
@@ -601,87 +600,79 @@ class test_models(SchedulerCase):
 
     def test_PeriodicTask_unicode_no_schedule(self):
         p = self.create_model()
-        assert str(p) == f'{p.name}: no schedule'
+        assert str(p) == f"{p.name}: no schedule"
 
     def test_CrontabSchedule_schedule(self):
-        s = CrontabSchedule(
-            minute='3, 7',
-            hour='3, 4',
-            day_of_week='*',
-            day_of_month='1, 16',
-            month_of_year='1, 7',
+        ks = CrontabSchedule(
+            minute="3, 7",
+            hour="3, 4",
+            day_of_week="*",
+            day_of_month="1, 16",
+            month_of_year="1, 7",
         )
-        assert s.schedule.minute == {3, 7}
-        assert s.schedule.hour == {3, 4}
-        assert s.schedule.day_of_week == {0, 1, 2, 3, 4, 5, 6}
-        assert s.schedule.day_of_month == {1, 16}
-        assert s.schedule.month_of_year == {1, 7}
+        assert ks.schedule.minute == {3, 7}
+        assert ks.schedule.hour == {3, 4}
+        assert ks.schedule.day_of_week == {0, 1, 2, 3, 4, 5, 6}
+        assert ks.schedule.day_of_month == {1, 16}
+        assert ks.schedule.month_of_year == {1, 7}
 
     def test_CrontabSchedule_long_schedule(self):
-        s = CrontabSchedule(
+        ks = CrontabSchedule(
             minute=str(list(range(60)))[1:-1],
             hour=str(list(range(24)))[1:-1],
             day_of_week=str(list(range(7)))[1:-1],
             day_of_month=str(list(range(1, 32)))[1:-1],
-            month_of_year=str(list(range(1, 13)))[1:-1]
+            month_of_year=str(list(range(1, 13)))[1:-1],
         )
-        assert s.schedule.minute == set(range(60))
-        assert s.schedule.hour == set(range(24))
-        assert s.schedule.day_of_week == set(range(7))
-        assert s.schedule.day_of_month == set(range(1, 32))
-        assert s.schedule.month_of_year == set(range(1, 13))
-        fields = [
-            'minute', 'hour', 'day_of_week', 'day_of_month', 'month_of_year'
-        ]
+        assert ks.schedule.minute == set(range(60))
+        assert ks.schedule.hour == set(range(24))
+        assert ks.schedule.day_of_week == set(range(7))
+        assert ks.schedule.day_of_month == set(range(1, 32))
+        assert ks.schedule.month_of_year == set(range(1, 13))
+        fields = ["minute", "hour", "day_of_week", "day_of_month", "month_of_year"]
         for field in fields:
-            str_length = len(str(getattr(s.schedule, field)))
+            str_length = len(str(getattr(ks.schedule, field)))
             field_length = getattr(CrontabSchedule, field, None).type.length
             assert str_length <= field_length
 
     def test_SolarSchedule_schedule(self):
-        s = SolarSchedule(event='solar_noon', latitude=48.06, longitude=12.86)
+        ks = SolarSchedule(event="solar_noon", latitude=48.06, longitude=12.86)
         dt = datetime(day=26, month=7, year=2050, hour=1, minute=0)
-        dt_lastrun = make_aware(dt, ZoneInfo('UTC'))
+        dt_lastrun = make_aware(dt, ZoneInfo("UTC"))
 
-        assert s.schedule is not None
-        isdue, nextcheck = s.schedule.is_due(dt_lastrun)
+        assert ks.schedule is not None
+        isdue, nextcheck = ks.schedule.is_due(dt_lastrun)
         assert isdue is False  # False means task isn't due, but keep checking.
-        assert (nextcheck > 0) and (isdue is False) or \
-            (nextcheck == s.max_interval) and (isdue is True)
+        assert (nextcheck > 0) and (isdue is False) or (nextcheck == ks.max_interval) and (isdue is True)
 
-        s2 = SolarSchedule(event='solar_noon', latitude=48.06, longitude=12.86)
+        s2 = SolarSchedule(event="solar_noon", latitude=48.06, longitude=12.86)
         dt2 = datetime(day=26, month=7, year=2000, hour=1, minute=0)
-        dt2_lastrun = make_aware(dt2, ZoneInfo('UTC'))
+        dt2_lastrun = make_aware(dt2, ZoneInfo("UTC"))
 
         assert s2.schedule is not None
         isdue2, nextcheck2 = s2.schedule.is_due(dt2_lastrun)
         assert isdue2 is True  # True means task is due and should run.
-        assert (nextcheck2 > 0) and (isdue2 is True) or \
-            (nextcheck2 == s2.max_interval) and (isdue2 is False)
+        assert (nextcheck2 > 0) and (isdue2 is True) or (nextcheck2 == s2.max_interval) and (isdue2 is False)
 
     def test_ClockedSchedule_schedule(self):
-        due_datetime = make_aware(datetime(day=26,
-                                           month=7,
-                                           year=3000,
-                                           hour=1,
-                                           minute=0),
-                                  ZoneInfo('UTC'))  # future time
-        s = ClockedSchedule(clocked_time=due_datetime)
+        due_datetime = make_aware(
+            datetime(day=26, month=7, year=3000, hour=1, minute=0), ZoneInfo("UTC")
+        )  # future time
+        ks = ClockedSchedule(clocked_time=due_datetime)
         dt = datetime(day=25, month=7, year=2050, hour=1, minute=0)
-        dt_lastrun = make_aware(dt, ZoneInfo('UTC'))
+        dt_lastrun = make_aware(dt, ZoneInfo("UTC"))
 
-        assert s.schedule is not None
-        isdue, nextcheck = s.schedule.is_due(dt_lastrun)
+        assert ks.schedule is not None
+        isdue, nextcheck = ks.schedule.is_due(dt_lastrun)
         assert isdue is False  # False means task isn't due, but keep checking.
-        assert (nextcheck > 0) and (isdue is False) or \
-            (nextcheck == s.max_interval) and (isdue is True)
+        assert (nextcheck > 0) and (isdue is False) or (nextcheck == ks.max_interval) and (isdue is True)
 
-        due_datetime = make_aware(datetime.now(), ZoneInfo('UTC'))
-        s = ClockedSchedule(clocked_time=due_datetime)
-        dt2_lastrun = make_aware(datetime.now(), ZoneInfo('UTC'))
+        due_datetime = make_aware(datetime.now(), ZoneInfo("UTC"))
+        ks = ClockedSchedule(clocked_time=due_datetime)
+        dt2_lastrun = make_aware(datetime.now(), ZoneInfo("UTC"))
 
-        assert s.schedule is not None
-        isdue2, nextcheck2 = s.schedule.is_due(dt2_lastrun)
+        assert ks.schedule is not None
+        isdue2, nextcheck2 = ks.schedule.is_due(dt2_lastrun)
         assert isdue2 is True  # True means task is due and should run.
         assert (nextcheck2 == NEVER_CHECK_TIMEOUT) and (isdue2 is True)
 
@@ -698,11 +689,11 @@ class test_models(SchedulerCase):
         assert p.schedule_id == 1
         assert c.schedule_id == 1
 
-        assert p.discriminator == 'intervalschedule'
+        assert p.discriminator == "intervalschedule"
         assert p.model_crontabschedule is None
         assert p.model_intervalschedule is not None
 
-        assert c.discriminator == 'crontabschedule'
+        assert c.discriminator == "crontabschedule"
         assert c.model_crontabschedule is not None
         assert c.model_intervalschedule is None
 
@@ -710,30 +701,31 @@ class test_models(SchedulerCase):
         with session_cleanup(self.session):
             interval = IntervalSchedule.from_schedule(self.session, schedule(timedelta(seconds=3)))
             p = PeriodicTask(
-                name=f'thefoo{next(_ids)}',
-                task=f'djcelery.unittest.add{next(_ids)}',
-                schedule_model=interval
+                name=f"thefoo{next(_ids)}",
+                task=f"djcelery.unittest.add{next(_ids)}",
+                schedule_model=interval,
+                **self.audit_dict,
             )
-            assert p.args == '[]'
-            assert p.kwargs == '{}'
-            assert p.headers == '{}'
+            assert p.args == "[]"
+            assert p.kwargs == "{}"
+            assert p.headers == "{}"
             assert p.one_off == False
             assert p.enabled == True
             assert p.total_run_count == 0
 
             self.session.add(p)
             self.session.flush()
-            assert p.args == '[]'
-            assert p.kwargs == '{}'
-            assert p.headers == '{}'
+            assert p.args == "[]"
+            assert p.kwargs == "{}"
+            assert p.headers == "{}"
             assert p.one_off == False
             assert p.enabled == True
             assert p.total_run_count == 0
 
             self.session.commit()
-            assert p.args == '[]'
-            assert p.kwargs == '{}'
-            assert p.headers == '{}'
+            assert p.args == "[]"
+            assert p.kwargs == "{}"
+            assert p.headers == "{}"
             assert p.one_off == False
             assert p.enabled == True
             assert p.total_run_count == 0
@@ -744,7 +736,7 @@ class test_model_PeriodicTaskChanged(SchedulerCase):
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
-        self.app.conf.beat_dburi = 'sqlite:///tests/testing.db'
+        self.app.conf.beat_dburi = "sqlite:///tests/testing.db"
         Session = SessionManager()
         self.session = Session.session_factory(self.app.conf.beat_dburi)
 
@@ -756,7 +748,7 @@ class test_model_PeriodicTaskChanged(SchedulerCase):
             self.session.commit()
             x = PeriodicTaskChanged.last_change(self.session)
             assert x
-            m1.args = '(23, 24)'
+            m1.args = "(23, 24)"
             self.session.add(m1)
             self.session.commit()
             y = PeriodicTaskChanged.last_change(self.session)


### PR DESCRIPTION
# [NVOMS-2986 ](https://omnipro.atlassian.net/browse/NVOMS-2986) - agregar submódul a Task para extender campos de auditoría

## ref [NVOMS-2986 ](https://omnipro.atlassian.net/browse/NVOMS-2986)

## Descripción

Adapta los cambios de la librería sqlalchme-celery-beat con los campos de auditoria que tenemos para registro de tiempo y usuario

## Cambios

Cambios realizados a los modelos de clocked, solar, interval, crontab, periodic_task para que acepten los nuevos campos

## Motivación y contexto

Estos cambios son para utilizar una adaptación a nuestra necesidad propia de un servicio de tareas programadas de un repo externo

## Cómo se prueba
Para probar los cambios es necesario invocar los servicios GRPC del microservicios de tarea

## Screenshots (si aplica)
\#N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [X] Nueva característica (cambios que añaden funcionalidad)
- [X] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [X] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [X] Mi código sigue las directrices de estilo de este proyecto
- [X] He realizado una auto-revisión de mi propio código
- [X] He comentado mi código, especialmente en áreas difíciles de entender
- [X] He hecho cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias
- [X] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [X] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [X] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
\#N/A