### PR TITLE
Add GitHub Actions workflow for publishing to PYPI and update package version to 0.8.1 NVOMS-4050

### DIFF
--- a/.github/workflows/release-library-pypi.yml
+++ b/.github/workflows/release-library-pypi.yml
@@ -1,0 +1,61 @@
+name: Generate Python Library & Publish on PYPI
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: master
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build
+          
+      - name: Get next version
+        id: generate_release_tag
+        uses: phish108/autotag-action@1.1.53
+        with:
+          github-token: ${{ secrets.TOKEN_GITHUB}}
+          with-v: "true"
+          bump: patch
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check Output Parameters
+        run: |
+          echo "Got tag name ${{ steps.generate_release_tag.outputs.new-tag }}"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+        with:
+          tag_name: ${{ steps.generate_release_tag.outputs.new-tag }}
+          release_name: Release ${{ steps.generate_release_tag.outputs.new-tag }}
+
+      - name: Upload Release Assets
+        id: upload-release-assets
+        uses: dwenegar/upload-release-assets@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}
+          assets_path: dist/
+
+      - name: Publish package to Custom PYPI
+        run: |
+          pip install twine
+          twine upload --repository-url https://pypi.omni.pro/root/omni-pro/ -u ${{ secrets.DEVPI_USER }} -p ${{ secrets.DEVPI_PASSWORD }} dist/*

--- a/setup.py
+++ b/setup.py
@@ -5,87 +5,78 @@
     :Copyright (c) 2023 Mohamed Farahat
     :license: MIT, see LICENSE for more details.
 """
-from os import path
+
 from codecs import open
+from os import path
+
 try:
     from setuptools import find_packages, setup
 except ImportError:
-    from distutils.core import setup, find_packages
+    from distutils.core import find_packages, setup
 # To use a consistent encoding
 
 basedir = path.abspath(path.dirname(__file__))
 # Get the long description from the README file
-with open(path.join(basedir, 'README.md'), encoding='utf-8') as f:
+with open(path.join(basedir, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
     name="sqlalchemy_celery_beat",
-
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.8.0",
+    version="0.8.1",
     # The project's main homepage.
     url="https://github.com/farahats9/sqlalchemy-celery-beat",
     # Choose your license
-
-    license='MIT',
-
+    license="MIT",
     description="A Scheduler Based SQLalchemy For Celery",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    platforms='any',
+    long_description_content_type="text/markdown",
+    platforms="any",
     # Author details
     author="Mohamed Farahat",
-    author_email='farahats9@yahoo.com',
-    home_page='https://github.com/farahats9/sqlalchemy-celery-beat',
-
+    author_email="farahats9@yahoo.com",
+    home_page="https://github.com/farahats9/sqlalchemy-celery-beat",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
-
+        "Development Status :: 3 - Alpha",
         # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries',
-
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
+        "License :: OSI Approved :: MIT License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
     ],
-
     # What does your project relate to?
     keywords="celery scheduler sqlalchemy beat",
-
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:
     #   py_modules=["my_module"],
-
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     entry_points={
-        'celery.beat_schedulers': [
-            'sqlalchemy = sqlalchemy_celery_beat.schedulers:DatabaseScheduler',
+        "celery.beat_schedulers": [
+            "sqlalchemy = sqlalchemy_celery_beat.schedulers:DatabaseScheduler",
         ],
     },
     install_requires=[
-        'celery>=5.0',
-        'sqlalchemy>=1.4',
-        'tzdata',
-        'ephem'
+        "celery>=5.0",
+        "sqlalchemy>=1.4",
+        "tzdata",
+        "ephem",
     ],
     zip_safe=False,
 )

--- a/sqlalchemy_celery_beat/models.py
+++ b/sqlalchemy_celery_beat/models.py
@@ -11,9 +11,8 @@ from zoneinfo import ZoneInfo, available_timezones
 import sqlalchemy as sa
 from celery import schedules
 from celery.utils.log import get_logger
-from celery.utils.time import make_aware, maybe_make_aware
+from celery.utils.time import maybe_make_aware
 from google.protobuf.wrappers_pb2 import BoolValue, FloatValue
-from omni.pro.user.access import INTERNAL_USER
 from omni_pro_grpc.v1.tasks.clocked_pb2 import Clocked as ClockedScheduleProto
 from omni_pro_grpc.v1.tasks.crontab_pb2 import Crontab as CrontabScheduleProto
 from omni_pro_grpc.v1.tasks.interval_pb2 import Interval as IntervalScheduleProto
@@ -21,7 +20,7 @@ from omni_pro_grpc.v1.tasks.periodic_task_pb2 import PeriodicTask as PeriodicTas
 from omni_pro_grpc.v1.tasks.solar_pb2 import Solar as SolarScheduleProto
 from sqlalchemy import event
 from sqlalchemy.future import Connection
-from sqlalchemy.orm import Session, backref, foreign, relationship, remote, validates
+from sqlalchemy.orm import Session, backref, foreign, relationship, remote
 from sqlalchemy.sql import insert, select, update
 
 from .clockedschedule import clocked
@@ -29,6 +28,8 @@ from .session import ModelBase
 from .tzcrontab import TzAwareCrontab
 
 logger = get_logger("sqlalchemy_celery_beat.models")
+
+INTERNAL_USER = "internal"
 
 
 class ModelMixin(object):

--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -13,10 +13,17 @@ from celery.utils.log import get_logger
 from celery.utils.time import maybe_make_aware
 from kombu.utils.encoding import safe_repr, safe_str
 from kombu.utils.json import dumps, loads
-from omni.pro.user.access import INTERNAL_USER
 
 from .clockedschedule import clocked
-from .models import ClockedSchedule, CrontabSchedule, IntervalSchedule, PeriodicTask, PeriodicTaskChanged, SolarSchedule
+from .models import (
+    INTERNAL_USER,
+    ClockedSchedule,
+    CrontabSchedule,
+    IntervalSchedule,
+    PeriodicTask,
+    PeriodicTaskChanged,
+    SolarSchedule,
+)
 from .session import SessionManager, session_cleanup
 from .time_utils import NEVER_CHECK_TIMEOUT
 
@@ -238,7 +245,7 @@ class ModelEntry(ScheduleEntry):
             {"schedule_model": model_schedule},
             args=dumps(args or []),
             kwargs=dumps(kwargs or {}),
-            **cls._unpack_options(**options or {})
+            **cls._unpack_options(**options or {}),
         )
         return entry
 
@@ -378,7 +385,7 @@ class DatabaseScheduler(Scheduler):
         except sa.exc.DatabaseError as exc:
             logger.exception("Database error while sync: %r", exc)
         except sa.exc.InterfaceError as exc:
-            logger.warning("DatabaseScheduler: InterfaceError in sync(), " "waiting to retry in next call...")
+            logger.warning("DatabaseScheduler: InterfaceError in sync(), " f"waiting to retry in next call... {exc}")
         finally:
             # retry later, only for the failed ones
             self._dirty |= _failed


### PR DESCRIPTION
# [NVOMS-4050](https://omnipro.atlassian.net/browse/NVOMS-4050) - Ticket: Investigación de Creación de Tablas y Gestión de Permisos en ClickHouse para Reportes

## ref  [NVOMS-4049](https://omnipro.atlassian.net/browse/NVOMS-4049)  /  [NVOMS-4050](https://omnipro.atlassian.net/browse/NVOMS-4050) 

## Descripción

Se ha implementado un nuevo flujo de trabajo (workflow) de CI/CD para automatizar la generación y publicación de la librería en un repositorio PyPI personalizado. Adicionalmente, se ha realizado una refactorización para desacoplar el proyecto de dependencias externas (`omni.pro`) definiendo constantes locales, se ha corregido el formato de logs y se ha incrementado la versión del paquete.

## Cambios detallados

* **Nuevo Workflow (.github/workflows/release-library-pypi.yml):**
* Se creó un archivo de GitHub Actions que se dispara en la rama `develop`.
* Automatiza el "bump" de versión (patch), la construcción del paquete y la publicación en `pypi.omni.pro`.


* **Refactorización de Modelos y Schedulers:**
* `sqlalchemy_celery_beat/models.py`: Se eliminó la importación de `INTERNAL_USER` desde `omni.pro.user.access`. Ahora la constante se define localmente (`INTERNAL_USER = "internal"`). Se eliminaron importaciones no utilizadas (`validates`, `make_aware`).
* `sqlalchemy_celery_beat/schedulers.py`: Se actualizó la importación de `INTERNAL_USER` para obtenerla desde el módulo local `.models` en lugar de la librería externa.
* **Corrección de Logs:** En `schedulers.py`, se corrigió una cadena de registro (log) agregando una `f-string` para que la excepción (`exc`) se imprima correctamente cuando ocurre un `InterfaceError`.


* **Configuración del Paquete (setup.py):**
* Se actualizó la versión de `0.8.0` a `0.8.1`.
* Se aplicaron correcciones de estilo y formato (uso de comillas dobles, orden de imports) para cumplir con estándares de PEP8/Black.



## Motivación y contexto

* **Automatización:** Es necesario agilizar el proceso de despliegue de nuevas versiones de la librería hacia el repositorio privado de la organización sin intervención manual propensa a errores.
* **Desacoplamiento:** La dependencia directa de `omni.pro.user.access` para obtener una simple constante de texto generaba un acoplamiento innecesario. Definir `INTERNAL_USER` localmente hace que esta librería sea más independiente y evita errores de importación si el paquete `omni` no está presente.
* **Depuración:** El log de error en `DatabaseScheduler` no estaba interpolando la variable de excepción, lo que dificultaba el diagnóstico de problemas de conexión con la base de datos; esto se ha corregido.

## Cómo se prueba

1. **Validación del CI/CD:**
* Hacer un `push` a la rama `develop`.
* Verificar en la pestaña "Actions" de GitHub que el workflow "Generate Python Library & Publish on PYPI" se ejecute correctamente.
* Confirmar que se haya creado un nuevo *Release* y que el paquete exista en el PyPI destino con la versión `0.8.1`.


2. **Prueba de funcionamiento:**
* Instalar la librería localmente.
* Ejecutar el proceso `celery beat`.
* Validar que no se arroje un `ImportError` buscando el módulo `omni.pro`.

## Screenshots (si aplica)
\#N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [X] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [X] Mi código sigue las directrices de estilo de este proyecto
- [X] He realizado una auto-revisión de mi propio código
- [X] He comentado mi código, especialmente en áreas difíciles de entender
- [X] He hecho cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias
- [X] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [X] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [X] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales


[NVOMS-4050]: https://omnipro.atlassian.net/browse/NVOMS-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NVOMS-4049]: https://omnipro.atlassian.net/browse/NVOMS-4049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NVOMS-4050]: https://omnipro.atlassian.net/browse/NVOMS-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ